### PR TITLE
Changes to query config logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,64 +45,6 @@
             "type": "string",
             "default": "build/axiom",
             "description": "Path where circuit outputs from compiled circuits will be written"
-          },
-          "axiom.circuits": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "title": "circuit",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Circuit Name"
-                },
-                "circuitPath": {
-                  "type": "string",
-                  "description": "Circuit File Path"
-                },
-                "buildPath": {
-                  "type": "string",
-                  "description": "Circuit Build File Path"
-                },
-                "defaultInputPath": {
-                  "type": "string",
-                  "description": "Default Input File Path"
-                },
-                "queries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "title": "query",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "Query Name"
-                      },
-                      "inputPath": {
-                        "type": "string",
-                        "description": "Input File Path"
-                      },
-                      "outputPath": {
-                        "type": "string",
-                        "description": "Output File Path"
-                      },
-                      "callbackAddress": {
-                        "type": "string",
-                        "description": "Callback Address"
-                      },
-                      "refundAddress": {
-                        "type": "string",
-                        "description": "Refund Address"
-                      }
-                    }
-                  }
-                },
-                "default": [],
-                "description": "Queries Configuration"
-              }
-            },
-            "default": [],
-            "description": "Circuits Configuration"
           }
         }
       }

--- a/src/commands/add-query.ts
+++ b/src/commands/add-query.ts
@@ -2,42 +2,55 @@ import * as vscode from "vscode";
 import { Circuit } from "../models/circuit";
 import { Query } from "../models/query";
 import { CircuitsTree } from "../views/circuits-tree";
-import * as path from "path";
+import { COMMAND_ID_UPDATE_QUERY_INPUT } from "./update-query";
+import { StateStore } from "../state";
 
 export const COMMAND_ID_ADD_QUERY = "axiom-crypto.add-query";
 
 export class AddQuery implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
+    stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_ADD_QUERY,
-        async (treeItem: { circuit: Circuit }) => {
+        async ({ circuit }: { circuit: Circuit }) => {
           console.log("add query");
-          vscode.window.showInformationMessage("Add Query");
-          const queryName =
-            "query" + (treeItem.circuit.queries.length + 1).toString();
-          const buildPathPrefix = treeItem.circuit.buildPath.path.substring(
-            0,
-            treeItem.circuit.buildPath.path.lastIndexOf("/"),
-          );
-          const outputPath = path.join(
-            buildPathPrefix,
-            treeItem.circuit.name,
+
+          const queryName = "query" + (circuit.queries.length + 1).toString();
+
+          const outputPath = vscode.Uri.joinPath(
+            circuit.buildPath,
+            circuit.name,
             queryName,
             "output.json",
           );
-          treeItem.circuit.queries.push(
-            new Query({
-              name: queryName,
-              inputPath: vscode.Uri.parse(""),
-              outputPath: vscode.Uri.parse(outputPath),
-              refundAddress: "0x0" as `0x${string}`,
-              callbackAddress: "0x0" as `0x${string}`,
-            }),
-          );
+
+          const query = new Query({
+            name: queryName,
+            circuit: circuit,
+            outputPath: outputPath,
+            refundAddress: "0x0" as `0x${string}`,
+            callbackAddress: "0x0" as `0x${string}`,
+          });
+          circuit.queries.push(query);
+          stateStore.updateState(circuit);
+
+          vscode.window
+            .showInformationMessage(
+              `Added new query named '${queryName}'`,
+              "Set query input...",
+            )
+            .then((choice) => {
+              if (choice === "Set query input...") {
+                vscode.commands.executeCommand(COMMAND_ID_UPDATE_QUERY_INPUT, {
+                  query,
+                });
+              }
+            });
+
           circuitsTree.refresh();
         },
       ),

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -27,16 +27,19 @@ export class Compile implements vscode.Disposable {
           }
 
           // set default inputs
-          if (circuit.defaultInputs.path === "/") {
+          if (circuit.defaultInputs === undefined) {
             for (const query of circuit.queries) {
-              if (query.inputPath.path !== "/") {
+              if (query.inputPath !== undefined) {
                 circuit.defaultInputs = query.inputPath;
               }
             }
           }
 
           // make sure default inputs are set
-          if (circuit.defaultInputs.path === "/") {
+          // TODO: this is a bit clunky, the user should be able to use
+          // an input that isn't part of a query, or they should be able
+          // to use typescript exports to define the default inputs
+          if (circuit.defaultInputs === undefined) {
             vscode.window.showErrorMessage(
               "You must add a query and set an input file before compiling",
             );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,14 +32,22 @@ export function registerCommands(
   context.subscriptions.push(new CompileAll(context));
   context.subscriptions.push(new Run(context));
   context.subscriptions.push(new SendQuery(context));
-  context.subscriptions.push(new AddQuery(context, circuitsTree));
-  context.subscriptions.push(new RenameQuery(context, circuitsTree));
+  context.subscriptions.push(new AddQuery(context, circuitsTree, stateStore));
+  context.subscriptions.push(
+    new RenameQuery(context, circuitsTree, stateStore),
+  );
   context.subscriptions.push(
     new DeleteQuery(context, circuitsTree, stateStore),
   );
-  context.subscriptions.push(new UpdateQueryInput(context, circuitsTree));
-  context.subscriptions.push(new UpdateQueryCallback(context, circuitsTree));
-  context.subscriptions.push(new UpdateQueryRefund(context, circuitsTree));
+  context.subscriptions.push(
+    new UpdateQueryInput(context, circuitsTree, stateStore),
+  );
+  context.subscriptions.push(
+    new UpdateQueryCallback(context, circuitsTree, stateStore),
+  );
+  context.subscriptions.push(
+    new UpdateQueryRefund(context, circuitsTree, stateStore),
+  );
   context.subscriptions.push(new ShowCircuitSource(context));
   context.subscriptions.push(new ConfigureParameters(context));
   context.subscriptions.push(new RefreshConfig(context, circuitsTree));

--- a/src/commands/update-query.ts
+++ b/src/commands/update-query.ts
@@ -15,30 +15,32 @@ export const COMMAND_ID_UPDATE_QUERY_REFUND =
 
 export class RenameQuery implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
+    stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_RENAME_QUERY,
-        async (treeItem: { query: Query; circuit: Circuit }) => {
-          console.log("Rename Query", treeItem);
+        async ({ query }: { query: Query }) => {
+          console.log("Rename Query", query);
           const updatedName = await vscode.window.showInputBox({
-            value: treeItem.query.name,
+            value: query.name,
           });
           if (updatedName !== undefined) {
-            treeItem.query.name = updatedName;
-            const buildPathPrefix = treeItem.circuit.buildPath.path.substring(
+            query.name = updatedName;
+            const buildPathPrefix = query.circuit.buildPath.path.substring(
               0,
-              treeItem.circuit.buildPath.path.lastIndexOf("/"),
+              query.circuit.buildPath.path.lastIndexOf("/"),
             );
             const outputPath = path.join(
               buildPathPrefix,
-              treeItem.circuit.name,
+              query.circuit.name,
               updatedName,
               "output.json",
             );
-            treeItem.query.outputPath = vscode.Uri.parse(outputPath);
+            query.outputPath = vscode.Uri.parse(outputPath);
+            stateStore.updateState(query.circuit);
             circuitsTree.refresh();
           }
         },
@@ -50,11 +52,11 @@ export class RenameQuery implements vscode.Disposable {
 
 export class DeleteQuery implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
     stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_DELETE_QUERY,
         async (treeItem: { query: Query | undefined; circuit: Circuit }) => {
@@ -74,19 +76,26 @@ export class DeleteQuery implements vscode.Disposable {
 
 export class UpdateQueryInput implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
+    stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_UPDATE_QUERY_INPUT,
-        async (treeItem: { query: Query }) => {
-          console.log("Update Query Input", treeItem);
-          const updatedInput = await vscode.window.showOpenDialog();
+        async ({ query }: { query: Query }) => {
+          console.log("Update Query Input", { query });
+          const updatedInput = await vscode.window.showOpenDialog({
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: { JSON: ["json"] },
+            openLabel: "Select as Input",
+            title: "Select File for Query Input",
+          });
           if (updatedInput !== undefined) {
             const inputPath = updatedInput[0].path;
-            console.log(inputPath);
-            treeItem.query.inputPath = vscode.Uri.parse(inputPath);
+            query.inputPath = vscode.Uri.parse(inputPath);
+            await stateStore.updateState(query.circuit);
             circuitsTree.refresh();
           }
         },
@@ -98,22 +107,22 @@ export class UpdateQueryInput implements vscode.Disposable {
 
 export class UpdateQueryCallback implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
+    stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_UPDATE_QUERY_CALLBACK,
-        async (treeItem: { query: Query }) => {
-          console.log("Update Query Callback", treeItem);
+        async ({ query }: { query: Query }) => {
+          console.log("Update Query Callback", query);
           const updatedCallback = await vscode.window.showInputBox({
-            value: treeItem.query.callbackAddress,
+            value: query.callbackAddress,
           });
           if (updatedCallback !== undefined) {
-            treeItem.query.callbackAddress = updatedCallback as `0x${string}`;
-            console.log(
-              `updated query callback - ${treeItem.query.callbackAddress}`,
-            );
+            query.callbackAddress = updatedCallback as `0x${string}`;
+            console.log(`updated query callback - ${query.callbackAddress}`);
+            await stateStore.updateState(query.circuit);
             circuitsTree.refresh();
           }
         },
@@ -125,19 +134,21 @@ export class UpdateQueryCallback implements vscode.Disposable {
 
 export class UpdateQueryRefund implements vscode.Disposable {
   constructor(
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     circuitsTree: CircuitsTree,
+    stateStore: StateStore,
   ) {
-    this.context.subscriptions.push(
+    context.subscriptions.push(
       vscode.commands.registerCommand(
         COMMAND_ID_UPDATE_QUERY_REFUND,
-        async (treeItem: { query: Query }) => {
-          console.log("Update Query Refund", treeItem);
+        async ({ query }: { query: Query }) => {
+          console.log("Update Query Refund", query);
           const updatedRefund = await vscode.window.showInputBox({
-            value: treeItem.query.refundAddress,
+            value: query.refundAddress,
           });
           if (updatedRefund !== undefined) {
-            treeItem.query.refundAddress = updatedRefund as `0x${string}`;
+            query.refundAddress = updatedRefund as `0x${string}`;
+            await stateStore.updateState(query.circuit);
             circuitsTree.refresh();
           }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { registerCustomListeners } from "./listeners";
 export async function activate(context: vscode.ExtensionContext) {
   // create and populate local state store
   const stateStore = new StateStore(context);
-  await stateStore.loadFromExtensionSettings();
+  await stateStore.reloadFromExtensionSettings();
 
   // create the tree view
   const circuitsTree = new CircuitsTree(stateStore);

--- a/src/listeners/index.ts
+++ b/src/listeners/index.ts
@@ -21,7 +21,7 @@ export function registerCustomListeners(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration("axiom")) {
         // update local state from the new settings
-        await stateStore.loadFromExtensionSettings();
+        await stateStore.reloadFromExtensionSettings();
 
         // re-draw the circuits tree view
         circuitsTree.refresh();
@@ -68,7 +68,7 @@ class CircuitsPatternFsWatcher {
     console.log(`${uri.fsPath} changed, refreshing state`);
 
     // update local state from the new settings
-    await this._stateStore.loadFromExtensionSettings();
+    await this._stateStore.reloadFromExtensionSettings();
 
     // re-draw the circuits tree view
     this._circuitsTree.refresh();

--- a/src/models/circuit.ts
+++ b/src/models/circuit.ts
@@ -7,7 +7,7 @@ export class Circuit {
   constructor(
     public source: CircuitSource,
     public buildPath: vscode.Uri,
-    public defaultInputs: vscode.Uri,
+    public defaultInputs: vscode.Uri | undefined,
   ) {}
 
   get name(): string {

--- a/src/models/query.ts
+++ b/src/models/query.ts
@@ -1,28 +1,30 @@
 import * as vscode from "vscode";
-import type { buildSendQuery } from "@axiom-crypto/client";
 import type { Circuit } from "./circuit";
 
 export class Query {
   name: string;
-  inputPath: vscode.Uri;
+  circuit: Circuit;
+  inputPath?: vscode.Uri;
   outputPath: vscode.Uri;
 
-  callbackAddress: `0x${string}`;
+  callbackAddress?: `0x${string}`;
   callbackExtraData?: `0x${string}`;
 
-  refundAddress: `0x${string}`;
+  refundAddress?: `0x${string}`;
 
-  sendQueryArgs?: Awaited<ReturnType<typeof buildSendQuery>>;
+  // sendQueryArgs?: Awaited<ReturnType<typeof buildSendQuery>>;
   txId?: string;
 
   constructor(args: {
     name: string;
-    inputPath: vscode.Uri;
+    circuit: Circuit;
+    inputPath?: vscode.Uri;
     outputPath: vscode.Uri;
-    callbackAddress: `0x${string}`;
-    refundAddress: `0x${string}`;
+    callbackAddress?: `0x${string}`;
+    refundAddress?: `0x${string}`;
   }) {
     this.name = args.name;
+    this.circuit = args.circuit;
     this.inputPath = args.inputPath;
     this.outputPath = args.outputPath;
     this.callbackAddress = args.callbackAddress;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,48 @@
+import * as vscode from "vscode";
+import type { SetRequired } from "type-fest";
+import { Query } from "../models/query";
+import { COMMAND_ID_UPDATE_QUERY_INPUT } from "../commands/update-query";
+
+export async function getProviderOrShowError(): Promise<string | undefined> {
+  const provider: string =
+    vscode.workspace.getConfiguration().get("axiom.providerURI") ?? "";
+  if (provider.length === 0) {
+    const choice = await vscode.window.showErrorMessage(
+      "You must set a provider URI before running a Query",
+      "Open Axiom settings...",
+    );
+    if (choice === "Open Axiom settings...") {
+      vscode.commands.executeCommand(
+        "workbench.action.openWorkspaceSettings",
+        "axiom",
+      );
+    }
+    return;
+  }
+}
+
+export type QueryWithAllValuesSet = SetRequired<
+  Query,
+  "inputPath" | "callbackAddress" | "refundAddress"
+>;
+
+export function assertQueryIsValid(
+  query: Query,
+): query is QueryWithAllValuesSet {
+  if (query.inputPath === undefined) {
+    vscode.window
+      .showErrorMessage(
+        "You must first set the input file for this query",
+        "Set input file path...",
+      )
+      .then((choice) => {
+        if (choice === "Set input file path...") {
+          vscode.commands.executeCommand(COMMAND_ID_UPDATE_QUERY_INPUT, {
+            query,
+          });
+        }
+      });
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Changes

- No longer track Circuits and Queries in the extension settings. Makes the StateStore the only storage of state. While I see the benefits of letting the user jump into settings.json to customize their circuits config, I don't think it's worth the confusion that brings.
- Adds buttons to some of the notification popups that prompts the user to select a query's input
  - ![Screenshot 2024-01-16 at 11 02 18 AM](https://github.com/standard-crypto/axiom-vscode/assets/2490863/461a9111-a60d-4bbf-b0a0-6e195d9bbc4f)
- Commands in `update-query.ts` now persist the changes that are made to queries
- Adds some validation logic if a user tries to run/submit a query without setting its input first
- Some small improvements to the file picker dialog
- Some best-effort logic to re-wire Queries back to their parent Circuit if the list of circuits changes
- Fix serialization/deserialization logic in `state.ts`

What I see remaining:
- Need a way to set a circuit's `defaultInput`. I figure we should add a row to the tree at the same height as the "Queries" header, which has the same appearance and behavior as the query input row
- Finish implementing run/send query
- Some comments on your original PR