### PR TITLE
upgrade axiom sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
         "icon": "$(file-add)"
       },
       {
+        "command": "axiom-crypto.update-circuit-input-schema",
+        "title": "Update Circuit Input Schema",
+        "icon": "$(file-add)"
+      },
+      {
         "command": "axiom-crypto.compile",
         "title": "Compile Circuit",
         "icon": "$(circuit-board)"
@@ -132,13 +137,18 @@
       "view/item/context": [
         {
           "command": "axiom-crypto.compile",
-          "group": "inline@2",
+          "group": "inline@1",
           "when": "view == axiom-circuits && viewItem == circuit"
         },
         {
           "command": "axiom-crypto.update-circuit-default-input",
-          "group": "inline@2",
+          "group": "inline@1",
           "when": "view == axiom-circuits && viewItem == defaultInputFile"
+        },
+        {
+          "command": "axiom-crypto.update-circuit-input-schema",
+          "group": "inline@1",
+          "when": "view == axiom-circuits && viewItem == inputSchemaFile"
         },
         {
           "command": "axiom-crypto.rename-query",
@@ -167,7 +177,7 @@
         },
         {
           "command": "axiom-crypto.update-query-input",
-          "group": "inline@2",
+          "group": "inline@1",
           "when": "view == axiom-circuits && viewItem == inputFile"
         },
         {
@@ -211,9 +221,8 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@axiom-crypto/circuit": "^0.1.3",
-    "@axiom-crypto/client": "^0.1.3",
-    "@metamask/etherscan-link": "^3.0.0",
+    "@axiom-crypto/circuit": "^2.0.3",
+    "@axiom-crypto/client": "^2.0.3",
     "dotenv": "^16.3.1",
     "ethers": "^6.9.0"
   }

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { compile } from "@axiom-crypto/circuit";
+import { compile } from "@axiom-crypto/circuit/cliHandler";
 import { Circuit } from "../models/circuit";
 import {
   assertCircuitCanBeCompiled,
@@ -96,7 +96,7 @@ export async function rawCompile(provider: string, circuit: Circuit) {
     stats: false,
     function: circuit.source.functionName,
     inputs: circuit.defaultInputs?.fsPath,
-    output: circuit.buildPath.fsPath,
+    outputs: circuit.buildPath.fsPath,
     provider: provider,
   });
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,10 @@ import { Compile, TriggerCompile } from "./compile";
 import { Run } from "./run";
 import { SendQuery } from "./send-query";
 import { AddQuery } from "./add-query";
-import { UpdateCircuitDefaultInput } from "./update-circuit-default-input";
+import {
+  UpdateCircuitDefaultInput,
+  UpdateCircuitInputSchema,
+} from "./update-circuit";
 import {
   DeleteQuery,
   RenameQuery,
@@ -22,7 +25,7 @@ export * from "./run";
 export * from "./send-query";
 export * from "./add-query";
 export * from "./show-source";
-export * from "./update-circuit-default-input";
+export * from "./update-circuit";
 
 export function registerCommands(
   context: vscode.ExtensionContext,
@@ -36,6 +39,9 @@ export function registerCommands(
   context.subscriptions.push(new AddQuery(context, circuitsTree, stateStore));
   context.subscriptions.push(
     new UpdateCircuitDefaultInput(context, circuitsTree, stateStore),
+  );
+  context.subscriptions.push(
+    new UpdateCircuitInputSchema(context, circuitsTree, stateStore),
   );
   context.subscriptions.push(
     new RenameQuery(context, circuitsTree, stateStore),

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { run } from "@axiom-crypto/circuit";
+import { prove } from "@axiom-crypto/circuit/cliHandler";
 import type { Query } from "../models/query";
 import {
   getConfigValueOrShowError,
@@ -44,11 +44,11 @@ export class Run implements vscode.Disposable {
             async (progress) => {
               // run the query
               progress.report({ increment: 0, message: "Running query..." });
-              await run(query.circuit.source.filePath.fsPath, {
+              await prove(query.circuit.source.filePath.fsPath, {
                 stats: false,
                 function: query.circuit.source.functionName,
-                build: query.circuit.buildPath.fsPath,
-                output: query.outputPath.fsPath,
+                compiled: query.circuit.buildPath.fsPath,
+                outputs: query.outputPath.fsPath,
                 inputs: query.inputPath.fsPath,
                 provider: provider,
               });

--- a/src/commands/update-circuit.ts
+++ b/src/commands/update-circuit.ts
@@ -5,6 +5,8 @@ import { StateStore } from "../state";
 
 export const COMMAND_ID_UPDATE_CIRCUIT_DEFAULT_INPUT =
   "axiom-crypto.update-circuit-default-input";
+export const COMMAND_ID_UPDATE_CIRCUIT_INPUT_SCHEMA =
+  "axiom-crypto.update-circuit-input-schema";
 
 export class UpdateCircuitDefaultInput implements vscode.Disposable {
   constructor(
@@ -27,6 +29,37 @@ export class UpdateCircuitDefaultInput implements vscode.Disposable {
           if (updatedInput !== undefined) {
             const inputPath = updatedInput[0].path;
             circuit.defaultInputs = vscode.Uri.parse(inputPath);
+            await stateStore.updateState(circuit);
+            circuitsTree.refresh();
+          }
+        },
+      ),
+    );
+  }
+  dispose() {}
+}
+
+export class UpdateCircuitInputSchema implements vscode.Disposable {
+  constructor(
+    context: vscode.ExtensionContext,
+    circuitsTree: CircuitsTree,
+    stateStore: StateStore,
+  ) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        COMMAND_ID_UPDATE_CIRCUIT_INPUT_SCHEMA,
+        async ({ circuit }: { circuit: Circuit }) => {
+          console.log("Update Circuit Input Schema", { circuit });
+          const updatedInputSchema = await vscode.window.showOpenDialog({
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: { JSON: ["json"] },
+            openLabel: "Select Input Schema",
+            title: "Select File for Circuit Input Schema",
+          });
+          if (updatedInputSchema !== undefined) {
+            const inputSchemaPath = updatedInputSchema[0].path;
+            circuit.inputSchema = vscode.Uri.parse(inputSchemaPath);
             await stateStore.updateState(circuit);
             circuitsTree.refresh();
           }

--- a/src/models/circuit.ts
+++ b/src/models/circuit.ts
@@ -8,6 +8,7 @@ export class Circuit {
     public source: CircuitSource,
     public buildPath: vscode.Uri,
     public defaultInputs: vscode.Uri | undefined,
+    public inputSchema: vscode.Uri | undefined,
   ) {}
 
   get name(): string {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -10,6 +10,7 @@ interface SerializedState {
     functionName: string;
     buildPath: string;
     defaultInputs?: string;
+    inputSchema?: string;
     queries: Array<SerializedQuery>;
   }>;
 }
@@ -69,6 +70,7 @@ export class StateStore {
         filePath: circuit.source.filePath.toString(),
         functionName: circuit.source.functionName,
         defaultInputs: circuit.defaultInputs?.toString(),
+        inputSchema: circuit.inputSchema?.toString(),
         queries: serializedQueries,
       });
     }
@@ -93,6 +95,9 @@ export class StateStore {
         circuit.defaultInputs === undefined
           ? undefined
           : vscode.Uri.parse(circuit.defaultInputs),
+        circuit.inputSchema === undefined
+          ? undefined
+          : vscode.Uri.parse(circuit.inputSchema),
       );
       const queries = new Array<Query>();
       for (const serializedQuery of circuit.queries) {
@@ -131,7 +136,7 @@ export class StateStore {
     // check workspace for circuit files
     const circuitFiles = await vscode.workspace.findFiles(
       circuitFilesPattern,
-      "**​/node_modules/**",
+      "**/node_modules/**",
     );
     state.circuits = this._loadCircuitsFromWorkspace(
       circuitFiles,
@@ -151,6 +156,7 @@ export class StateStore {
     if (state.circuits.length === 1 && previousState.circuits.length === 1) {
       state.circuits[0].queries = previousState.circuits[0].queries;
       state.circuits[0].defaultInputs = previousState.circuits[0].defaultInputs;
+      state.circuits[0].inputSchema = previousState.circuits[0].inputSchema;
     }
 
     await this._saveState(state);
@@ -183,6 +189,7 @@ export class StateStore {
       const circuit = new Circuit(
         new CircuitSource(circuitFileUri, circuitName),
         buildPath,
+        undefined,
         undefined,
       );
       circuits.push(circuit);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
+		"skipLibCheck": true,
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,80 +12,69 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
   integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
-"@axiom-crypto/circuit@0.1.3", "@axiom-crypto/circuit@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/circuit/-/circuit-0.1.3.tgz#616e34a408089d03066b823d52c708af1f58c734"
-  integrity sha512-bUiRThj/6+WqMCq8vqBtolt1R7tJuJhlAZLcUIk1YzbXeTgR6ikz2CiY33yf8hJKxeaNY9fqjT3JgIxu38Z2SA==
+"@axiom-crypto/circuit@2.0.3", "@axiom-crypto/circuit@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/circuit/-/circuit-2.0.3.tgz#0e15e890dd612a71b345a3c4ab978d27e629c6c3"
+  integrity sha512-CoutK1HVo4TI1hUlzxtHdl9DIYjMPCpQfpxOeKKqghZURADpj4pDWrQivKzxePjlBmbdX7NyS/Ox98tyzXYmeA==
   dependencies:
-    "@axiom-crypto/core" "^2.2.50"
-    "@axiom-crypto/halo2-lib-js" "0.2.13-alpha.1"
-    "@axiom-crypto/halo2-wasm" "0.2.10"
-    "@axiom-crypto/tools" "^0.3.33"
+    "@axiom-crypto/core" "2.3.4"
+    "@axiom-crypto/halo2-lib-js" "0.3.4"
+    "@axiom-crypto/halo2-wasm" "0.3.4"
+    "@axiom-crypto/tools" "2.0.0"
     commander "^11.1.0"
     ethers "^6.8.1"
     viem "^1.19.9"
 
-"@axiom-crypto/client@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/client/-/client-0.1.3.tgz#dbd9a68aa518234ed42ff477d560789b457d8b6d"
-  integrity sha512-w4Adh+EW11n66zm16xTgIyZi6OoG63lSK8QUCtt1UlIgMgTtEFdXKl/LWtpOI5m1D7rnO4IBzIUpK9/zHTZohQ==
+"@axiom-crypto/client@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/client/-/client-2.0.3.tgz#75e9250d89dffdd94f601befcf819cc31c1c9447"
+  integrity sha512-1QgDOoPtHpOnUO2Bp9FSKwffg8yZyaw4jKeeinnZ9BLSP5JXZ9auqv2ui7P6cZIbbGvnymr8KUwJTyg94FSD6g==
   dependencies:
-    "@axiom-crypto/circuit" "0.1.3"
-    "@axiom-crypto/core" "^2.2.50"
-    "@axiom-crypto/halo2-lib-js" "0.2.13-alpha.1"
-    "@axiom-crypto/halo2-wasm" "0.2.10"
-    "@axiom-crypto/tools" "^0.3.33"
+    "@axiom-crypto/circuit" "2.0.3"
+    "@axiom-crypto/core" "2.3.4"
+    chalk "^4.1.2"
     commander "^11.1.0"
-    ethers "^6.8.1"
-    viem "^1.19.9"
+    prompts "^2.4.2"
+    viem "^2.3.1"
 
-"@axiom-crypto/core@^2.2.50":
-  version "2.2.50"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/core/-/core-2.2.50.tgz#e78a9bb94f274cddc188551b07230a15d2bde234"
-  integrity sha512-SWiTntwZsgpvnsCdGxajcnQ1H6sOil9L6l451B0892gSz1pC/XkyZ61JN+IwgUZFdNhF5B+hFdzK+WaMO7GAbw==
+"@axiom-crypto/core@2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/core/-/core-2.3.4.tgz#c6a0f31479f8ec9220fb7a2373b90206ec7bd67e"
+  integrity sha512-3CcxPB2nEVcNblCMd4xf7ZzX9UL0T0UMYmDY5cmFGnKNQcnQcaSUOn3Ke5IVB9GSvsublKTRN7EWPhIOuNw9mA==
   dependencies:
-    "@axiom-crypto/halo2-lib-js" "0.2.10"
-    "@axiom-crypto/halo2-wasm" "0.2.7"
-    "@axiom-crypto/tools" "^0.3.33"
+    "@axiom-crypto/tools" "2.0.0"
     axios "^1.6.1"
     bs58 "^5.0.0"
     ethers "^6.8.1"
     merkletreejs "^0.3.11"
 
-"@axiom-crypto/halo2-lib-js@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-lib-js/-/halo2-lib-js-0.2.10.tgz#2f9b9e02d1cdbdd635de3ea19811789622c63a40"
-  integrity sha512-gvO9fqB/w10q0RRoZ+Q9utvcWcDldHqIl4Jf8t9luoI+vXipZlyT8NIStykOvd6g64guymCnMeAv2vvObvHxIA==
+"@axiom-crypto/halo2-lib-js@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-lib-js/-/halo2-lib-js-0.3.4.tgz#3ffdf46a2020676bed74eba8918b7ced42ced530"
+  integrity sha512-E/i7EqlcvjcfXZejL8HcpvFQIIMJxcMrVBXsdaDJGgEXVc6pEDJ07Hy3drLbhQ007ZJ8aultw3HSfD9gJRkh4w==
   dependencies:
-    "@axiom-crypto/halo2-wasm" "0.2.7"
+    "@axiom-crypto/halo2-wasm" "0.3.4"
     ethers "^6.8.0"
     prettier "1.18.2"
 
-"@axiom-crypto/halo2-lib-js@0.2.13-alpha.1":
-  version "0.2.13-alpha.1"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-lib-js/-/halo2-lib-js-0.2.13-alpha.1.tgz#7476171c9d5d529aca826ae62ae130d8493beb39"
-  integrity sha512-RACC6uGkVNNZDJwsT7yrF/XEq9oSB/hylup78V8JYlYhp3/dZ6fAnbiEPuTe9xFMqDpIYeTN7KO/h6VEqktZfw==
-  dependencies:
-    "@axiom-crypto/halo2-wasm" "0.2.10"
-    ethers "^6.8.0"
-    prettier "1.18.2"
+"@axiom-crypto/halo2-wasm@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-wasm/-/halo2-wasm-0.3.4.tgz#c07a1d25149c84a0d3d2300f2d936160cb97e5c7"
+  integrity sha512-SUHXnydtx5rY0gQ2zWy0Br6L3iaAFo5RH/AMnOCSM4Nb3inqinBEnXQgEPZ45+EFmeOfRi1xOVUBdo6keZlacQ==
 
-"@axiom-crypto/halo2-wasm@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-wasm/-/halo2-wasm-0.2.10.tgz#a755a48cf06a461c2aa815171ae04e58e65fcf90"
-  integrity sha512-88VPIGeLUPYp+kIgKuJ4QBAKZ5SbwtJheBca5DuZdyb/9vGZ02gyeyQe6/2N7yVDIn3hupHhgfAc4mqm1/4ddw==
-
-"@axiom-crypto/halo2-wasm@0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/halo2-wasm/-/halo2-wasm-0.2.7.tgz#67cec91b6110415c40ecfdd30b1eac9735a1121f"
-  integrity sha512-pmgFCkCJUlFgh5NCLR59WpWIiBegNxBRAAlA2UxPMga1Pba02ynZgf6SW0tbQaezMiWUdTA9SfpeosovcNI6Yg==
-
-"@axiom-crypto/tools@^0.3.33":
-  version "0.3.33"
-  resolved "https://registry.yarnpkg.com/@axiom-crypto/tools/-/tools-0.3.33.tgz#304044740ae68600e9c85307ae9dd7ee03fb669d"
-  integrity sha512-1ABAgXIZ2bNqHKTBcYGsL0tNQrX6PLM/1fHnkuT6g4WgHBMCoZuXyuTQK/CdoxsK/L3y253v9YW/5WOD9FI0Og==
+"@axiom-crypto/tools@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@axiom-crypto/tools/-/tools-2.0.0.tgz#68f5ecadb5405864e61ed75cac86a24703cf30a9"
+  integrity sha512-zoNlRRTyS98xysKrui2g+/f+A6+LiSi7wNw1m+xbCcDkY5/yz52VkbpGt+DTfo5FboiqTaXAq5f5CidNg4Z0mQ==
   dependencies:
     ethers "^6.7.0"
+
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -163,6 +152,24 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@metamask/etherscan-link@^3.0.0":
   version "3.0.0"
@@ -259,6 +266,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/json-schema@^7.0.12":
   version "7.0.15"
@@ -410,10 +437,25 @@ abitype@0.9.8:
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.8.tgz#1f120b6b717459deafd213dfbf3a3dd1bf10ae8c"
   integrity sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==
 
+abitype@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.0.tgz#237176dace81d90d018bebf3a45cb42f2a2d9e97"
+  integrity sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.1.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
+acorn@^8.4.1:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.9.0:
   version "8.11.2"
@@ -476,6 +518,11 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -580,7 +627,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -655,6 +702,11 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -695,6 +747,11 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1232,6 +1289,11 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -1278,6 +1340,11 @@ lru-cache@^6.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.1.0.tgz#2098d41c2dc56500e6c88584aa656c84de7d0484"
   integrity sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -1504,6 +1571,14 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+prompts@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -1621,6 +1696,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -1718,6 +1798,25 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
   integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -1762,6 +1861,11 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 viem@^1.19.9:
   version "1.19.13"
   resolved "https://registry.yarnpkg.com/viem/-/viem-1.19.13.tgz#3a018720bd2abf54a039c751fc2bcd473838c523"
@@ -1773,6 +1877,20 @@ viem@^1.19.9:
     "@scure/bip32" "1.3.2"
     "@scure/bip39" "1.2.1"
     abitype "0.9.8"
+    isows "1.0.3"
+    ws "8.13.0"
+
+viem@^2.3.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.6.1.tgz#aaab145746e019fdb0a838e32c19bad69d6b2a15"
+  integrity sha512-565cKS2fQ8XU9sfQo5NGAZXdKwPFjof4nO3NUyElVHKqKw9l5/y2iDDMEubvxm09rBlzibJ+Sw/mI4jnnkQE4g==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@scure/bip32" "1.3.2"
+    "@scure/bip39" "1.2.1"
+    abitype "1.0.0"
     isows "1.0.3"
     ws "8.13.0"
 
@@ -1895,6 +2013,11 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- replaces old axiom logic
  - removes logic to manually kick off eth txns and instead uses axiom sdk to send query
  - copies in axiom code to transpile circuit file
- updates chain to sepolia
- adds new circuit tree item input schema file and updates models/commands/logic/validation to support it
